### PR TITLE
Ghi007 fix new mass tag

### DIFF
--- a/server/szuru-admin
+++ b/server/szuru-admin
@@ -296,8 +296,7 @@ def mass_tag(
     # get verbose printers
     vprint, vseparate = _vprinters(verbose)
 
-    # check if any tags need to be created, and/or apply implications to the
-    # given tags are needed
+    # check if any tags need to be created and/or if implications need to be applied to the given tags
     all_added = set()
     vprint("Checking new tags for tag existence" + (" and implications" if implications else "") + "...")
     tags_to_create = set()


### PR DESCRIPTION
Fixes error in mass tag when new tag was being added, adds audit logging, allows specification of preserving the old name on a rename of tags with --p option, updated mass tagging subcommand name to just `tag` to reflect common name of what it is, fixed some formatting in general, updated SQLAlchemy interactions to correctly signal mutations.